### PR TITLE
Support monday/tuesday observance rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * UNRELEASED
   * Added support for nth-day-of-the-week holidays
-  * Now supports observed holidays
+  * Now supports observed holidays, including UK Christmas/Boxing Day Monday/Tuesday rule
   * You can now specify a holiday to begin or end only after a certain year
 
 * 0.5.0 - Jan 7, 2022

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 ## Roadmap
 
-* Support multi-observance rule (i.e. Christmas Day + Boxing Day in the UK - https://www.timeanddate.com/holidays/uk/2027?hol=9)
 * Improve the API
 * Make defining your own calendars optional, so people don't need to generate a jar file
+* Add a few sensible default calendars
 * Improve README/docs after this
 * Support cljs
 * Non-saturday/sunday weekends

--- a/src/com/piposaude/calenjars/holidays.clj
+++ b/src/com/piposaude/calenjars/holidays.clj
@@ -14,7 +14,7 @@
 
 (defmulti opt-value (fn [opt-kw _args] opt-kw))
 
-(defmethod opt-value :observed [_ _] true)
+(defmethod opt-value :observation-rule [_ args] (keyword (first args)))
 (defmethod opt-value :start-year [_ args] (edn/read-string (first args)))
 (defmethod opt-value :end-year [_ args] (edn/read-string (first args)))
 
@@ -23,12 +23,12 @@
             (assoc holiday-opts opt-kw (opt-value opt-kw args))) {} opts))
 
 (defn get-holiday [year [_ name [type & args] opts]]
-  (let [{:keys [observed start-year end-year]} (parse-holiday-opts opts)]
+  (let [{:keys [observation-rule start-year end-year]} (parse-holiday-opts opts)]
     (condp = type
-      :ddmmm (ddmm/get-holiday-ddmm year name args observed start-year end-year)
+      :ddmmm (ddmm/get-holiday-ddmm year name args observation-rule start-year end-year)
       :ddmmmyyyy (ddmmyyyy/get-holiday-ddmmyyyy year name args)
       :nth-day-of-week (nth-day-of-week/get-holiday-nth-day-of-week year name args start-year end-year)
-      :expression (expression/get-holiday-by-expression year name (first args) observed start-year end-year)
+      :expression (expression/get-holiday-by-expression year name (first args) observation-rule start-year end-year)
       nil)))
 
 (defn remove-exceptions [holidays]

--- a/src/com/piposaude/calenjars/types/ddmmm.clj
+++ b/src/com/piposaude/calenjars/types/ddmmm.clj
@@ -5,7 +5,7 @@
             [tick.alpha.api :as t])
   (:import (java.time.format DateTimeParseException)))
 
-(defn get-holiday-ddmm [year name [day month] observed start-year end-year]
+(defn get-holiday-ddmm [year name [day month] observation-rule start-year end-year]
   (try
     (let [holiday (common/holiday name day month year)]
       (cond
@@ -15,11 +15,14 @@
         (and end-year (> year end-year))
         nil
 
-        (and observed (= t/SATURDAY (t/day-of-week (:date holiday))))
+        (and (= observation-rule :observed) (= t/SATURDAY (t/day-of-week (:date holiday))))
         (update holiday :date #(t/- % (t/new-period 1 :days)))
 
-        (and observed (= t/SUNDAY (t/day-of-week (:date holiday))))
+        (and (= observation-rule :observed) (= t/SUNDAY (t/day-of-week (:date holiday))))
         (update holiday :date #(t/+ % (t/new-period 1 :days)))
+
+        (and (= observation-rule :observed-monday-tuesday) (contains? #{t/SATURDAY t/SUNDAY} (t/day-of-week (:date holiday))))
+        (update holiday :date #(t/+ % (t/new-period 2 :days)))
 
         :else
         holiday))

--- a/src/com/piposaude/calenjars/types/expression.clj
+++ b/src/com/piposaude/calenjars/types/expression.clj
@@ -9,7 +9,7 @@
 
     nil))
 
-(defn get-holiday-by-expression [year name args observed start-year end-year]
+(defn get-holiday-by-expression [year name args observation-rule start-year end-year]
   (let [holiday (make-holiday year name args)]
     (cond
       (and start-year (< year start-year))
@@ -18,11 +18,14 @@
       (and end-year (> year end-year))
       nil
 
-      (and observed (= t/SATURDAY (t/day-of-week (:date holiday))))
+      (and (= observation-rule :observed) (= t/SATURDAY (t/day-of-week (:date holiday))))
       (update holiday :date #(t/- % (t/new-period 1 :days)))
 
-      (and observed (= t/SUNDAY (t/day-of-week (:date holiday))))
+      (and (= observation-rule :observed) (= t/SUNDAY (t/day-of-week (:date holiday))))
       (update holiday :date #(t/+ % (t/new-period 1 :days)))
+
+      (and (= observation-rule :observed-monday-tuesday) (contains? #{t/SATURDAY t/SUNDAY} (t/day-of-week (:date holiday))))
+      (update holiday :date #(t/+ % (t/new-period 2 :days)))
 
       :else
       holiday)))

--- a/src/holidays.bnf
+++ b/src/holidays.bnf
@@ -17,8 +17,9 @@ ddmmm = day-31 month-31 | day-30 month-30 | day-feb month-feb
 <month-30> = 'Apr' | 'Jun' | 'Sep' | 'Nov'
 <month-feb> = 'Feb'
 
-ddmmm-opts = observed? limit-clause? | limit-clause? observed?
-observed = <'|'> 'observed'
+ddmmm-opts = observation-rule? limit-clause? | limit-clause? observation-rule?
+observation-rule = <'|'> observation-rule-option
+<observation-rule-option> = 'observed' | 'observed-monday-tuesday'
 <limit-clause> = start-year | end-year
 start-year = <'|'> #'\d{4}' <'->'>
 end-year = <'|'> <'->'> #'\d{4}'
@@ -39,7 +40,7 @@ easter = 'E' expression-operator expression-operand
 <expression-operator> = '+' | '-'
 <expression-operand> = #'\d+'
 
-expression-opts = observed? limit-clause? | limit-clause? observed?
+expression-opts = observation-rule? limit-clause? | limit-clause? observation-rule?
 
 exception-marker = '-'
 

--- a/test-resources/generate/ddmmm-observed-monday-tuesday-end-reverse-order.hol
+++ b/test-resources/generate/ddmmm-observed-monday-tuesday-end-reverse-order.hol
@@ -1,0 +1,1 @@
+Christmas|25Dec|->2019|observed-monday-tuesday

--- a/test-resources/generate/ddmmm-observed-monday-tuesday-end.hol
+++ b/test-resources/generate/ddmmm-observed-monday-tuesday-end.hol
@@ -1,0 +1,1 @@
+Christmas|25Dec|observed-monday-tuesday|->2019

--- a/test-resources/generate/ddmmm-observed-monday-tuesday-start-reverse-order.hol
+++ b/test-resources/generate/ddmmm-observed-monday-tuesday-start-reverse-order.hol
@@ -1,0 +1,1 @@
+Christmas|25Dec|2018->|observed-monday-tuesday

--- a/test-resources/generate/ddmmm-observed-monday-tuesday-start.hol
+++ b/test-resources/generate/ddmmm-observed-monday-tuesday-start.hol
@@ -1,0 +1,1 @@
+Christmas|25Dec|observed-monday-tuesday|2018->

--- a/test-resources/generate/ddmmm-observed-monday-tuesday.hol
+++ b/test-resources/generate/ddmmm-observed-monday-tuesday.hol
@@ -1,0 +1,2 @@
+Christmas|25Dec|observed-monday-tuesday
+Boxing Day|26Dec|observed-monday-tuesday

--- a/test-resources/generate/expression-easter-observed-monday-tuesday-end-reverse-order.hol
+++ b/test-resources/generate/expression-easter-observed-monday-tuesday-end-reverse-order.hol
@@ -1,0 +1,1 @@
+Easter On Tuesday|E+0|->2016|observed-monday-tuesday

--- a/test-resources/generate/expression-easter-observed-monday-tuesday-end.hol
+++ b/test-resources/generate/expression-easter-observed-monday-tuesday-end.hol
@@ -1,0 +1,1 @@
+Easter On Tuesday|E+0|observed-monday-tuesday|->2016

--- a/test-resources/generate/expression-easter-observed-monday-tuesday-start-reverse-order.hol
+++ b/test-resources/generate/expression-easter-observed-monday-tuesday-start-reverse-order.hol
@@ -1,0 +1,1 @@
+Easter On Tuesday|E+0|2015->|observed-monday-tuesday

--- a/test-resources/generate/expression-easter-observed-monday-tuesday-start.hol
+++ b/test-resources/generate/expression-easter-observed-monday-tuesday-start.hol
@@ -1,0 +1,1 @@
+Easter On Tuesday|E+0|observed-monday-tuesday|2015->

--- a/test-resources/generate/expression-easter-observed-monday-tuesday.hol
+++ b/test-resources/generate/expression-easter-observed-monday-tuesday.hol
@@ -1,0 +1,1 @@
+Easter On Tuesday|E+0|observed-monday-tuesday

--- a/test/com/piposaude/calenjars/holidays_ddmmm_test.clj
+++ b/test/com/piposaude/calenjars/holidays_ddmmm_test.clj
@@ -38,6 +38,24 @@
     [{:name "Independence Day" :date (t/date "2020-07-03")}] 2020
     [{:name "Independence Day" :date (t/date "2021-07-05")}] 2021))
 
+(deftest should-generate-holidays-when-holidays-for-year-with-monday-tuesday-observance-rule-on-ddmmm
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/ddmmm-observed-monday-tuesday.hol"))
+    [{:name "Christmas" :date (t/date "2016-12-27")}
+     {:name "Boxing Day" :date (t/date "2016-12-26")}] 2016
+    [{:name "Christmas" :date (t/date "2017-12-25")}
+     {:name "Boxing Day" :date (t/date "2017-12-26")}] 2017
+    [{:name "Christmas" :date (t/date "2018-12-25")}
+     {:name "Boxing Day" :date (t/date "2018-12-26")}] 2018
+    [{:name "Christmas" :date (t/date "2019-12-25")}
+     {:name "Boxing Day" :date (t/date "2019-12-26")}] 2019
+    [{:name "Christmas" :date (t/date "2020-12-25")}
+     {:name "Boxing Day" :date (t/date "2020-12-28")}] 2020
+    [{:name "Christmas" :date (t/date "2021-12-27")}
+     {:name "Boxing Day" :date (t/date "2021-12-28")}] 2021
+    [{:name "Christmas" :date (t/date "2022-12-27")}
+     {:name "Boxing Day" :date (t/date "2022-12-26")}] 2022))
+
 (deftest should-generate-holidays-when-holidays-for-year-with-start-clause-on-ddmmm
   (are [expected year]
        (= expected (gen/holidays-for-year year "test-resources/generate/ddmmm-start.hol"))
@@ -75,6 +93,25 @@
     [{:name "Independence Day" :date (t/date "2020-07-03")}] 2020
     [{:name "Independence Day" :date (t/date "2021-07-05")}] 2021))
 
+(deftest should-generate-holidays-when-holidays-for-year-with-monday-tuesday-observance-rule-and-start-clause-on-ddmmm
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/ddmmm-observed-monday-tuesday-start.hol"))
+    [] 2016
+    [] 2017
+    [{:name "Christmas" :date (t/date "2018-12-25")}] 2018
+    [{:name "Christmas" :date (t/date "2019-12-25")}] 2019
+    [{:name "Christmas" :date (t/date "2020-12-25")}] 2020
+    [{:name "Christmas" :date (t/date "2021-12-27")}] 2021)
+
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/ddmmm-observed-monday-tuesday-start-reverse-order.hol"))
+    [] 2016
+    [] 2017
+    [{:name "Christmas" :date (t/date "2018-12-25")}] 2018
+    [{:name "Christmas" :date (t/date "2019-12-25")}] 2019
+    [{:name "Christmas" :date (t/date "2020-12-25")}] 2020
+    [{:name "Christmas" :date (t/date "2021-12-27")}] 2021))
+
 (deftest should-generate-holidays-when-holidays-for-year-with-end-clause-on-ddmmm
   (are [expected year]
        (= expected (gen/holidays-for-year year "test-resources/generate/ddmmm-end.hol"))
@@ -109,5 +146,24 @@
     [{:name "Independence Day" :date (t/date "2017-07-04")}] 2017
     [{:name "Independence Day" :date (t/date "2018-07-04")}] 2018
     [{:name "Independence Day" :date (t/date "2019-07-04")}] 2019
+    [] 2020
+    [] 2021))
+
+(deftest should-generate-holidays-when-holidays-for-year-with-monday-tuesday-observance-rule-and-end-clause-on-ddmmm
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/ddmmm-observed-monday-tuesday-end.hol"))
+    [{:name "Christmas" :date (t/date "2016-12-27")}] 2016
+    [{:name "Christmas" :date (t/date "2017-12-25")}] 2017
+    [{:name "Christmas" :date (t/date "2018-12-25")}] 2018
+    [{:name "Christmas" :date (t/date "2019-12-25")}] 2019
+    [] 2020
+    [] 2021)
+
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/ddmmm-observed-monday-tuesday-end-reverse-order.hol"))
+    [{:name "Christmas" :date (t/date "2016-12-27")}] 2016
+    [{:name "Christmas" :date (t/date "2017-12-25")}] 2017
+    [{:name "Christmas" :date (t/date "2018-12-25")}] 2018
+    [{:name "Christmas" :date (t/date "2019-12-25")}] 2019
     [] 2020
     [] 2021))

--- a/test/com/piposaude/calenjars/holidays_expression_easter_test.clj
+++ b/test/com/piposaude/calenjars/holidays_expression_easter_test.clj
@@ -32,6 +32,17 @@
     [{:name "Easter On Monday" :date (t/date "2017-04-17")}] 2017
     [{:name "Easter On Monday" :date (t/date "2018-04-02")}] 2018))
 
+(deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-and-monday-tuesday-observance-rule
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/expression-easter-observed-monday-tuesday.hol"))
+    [{:name "Easter On Tuesday" :date (t/date "2012-04-10")}] 2012
+    [{:name "Easter On Tuesday" :date (t/date "2013-04-02")}] 2013
+    [{:name "Easter On Tuesday" :date (t/date "2014-04-22")}] 2014
+    [{:name "Easter On Tuesday" :date (t/date "2015-04-07")}] 2015
+    [{:name "Easter On Tuesday" :date (t/date "2016-03-29")}] 2016
+    [{:name "Easter On Tuesday" :date (t/date "2017-04-18")}] 2017
+    [{:name "Easter On Tuesday" :date (t/date "2018-04-03")}] 2018))
+
 (deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-and-start-clause
   (are [expected year]
        (= expected (gen/holidays-for-year year "test-resources/generate/expression-easter-start.hol"))
@@ -75,6 +86,27 @@
     [{:name "Easter On Monday" :date (t/date "2017-04-17")}] 2017
     [{:name "Easter On Monday" :date (t/date "2018-04-02")}] 2018))
 
+(deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-with-monday-tuesday-observance-rule-and-start-clause
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/expression-easter-observed-monday-tuesday-start.hol"))
+    [] 2012
+    [] 2013
+    [] 2014
+    [{:name "Easter On Tuesday" :date (t/date "2015-04-07")}] 2015
+    [{:name "Easter On Tuesday" :date (t/date "2016-03-29")}] 2016
+    [{:name "Easter On Tuesday" :date (t/date "2017-04-18")}] 2017
+    [{:name "Easter On Tuesday" :date (t/date "2018-04-03")}] 2018)
+
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/expression-easter-observed-monday-tuesday-start-reverse-order.hol"))
+    [] 2012
+    [] 2013
+    [] 2014
+    [{:name "Easter On Tuesday" :date (t/date "2015-04-07")}] 2015
+    [{:name "Easter On Tuesday" :date (t/date "2016-03-29")}] 2016
+    [{:name "Easter On Tuesday" :date (t/date "2017-04-18")}] 2017
+    [{:name "Easter On Tuesday" :date (t/date "2018-04-03")}] 2018))
+
 (deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-and-end-clause
   (are [expected year]
        (= expected (gen/holidays-for-year year "test-resources/generate/expression-easter-end.hol"))
@@ -115,5 +147,26 @@
     [{:name "Easter On Monday" :date (t/date "2014-04-21")}] 2014
     [{:name "Easter On Monday" :date (t/date "2015-04-06")}] 2015
     [{:name "Easter On Monday" :date (t/date "2016-03-28")}] 2016
+    [] 2017
+    [] 2018))
+
+(deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-with-monday-tuesday-observance-rule-and-end-clause
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/expression-easter-observed-monday-tuesday-end.hol"))
+    [{:name "Easter On Tuesday" :date (t/date "2012-04-10")}] 2012
+    [{:name "Easter On Tuesday" :date (t/date "2013-04-02")}] 2013
+    [{:name "Easter On Tuesday" :date (t/date "2014-04-22")}] 2014
+    [{:name "Easter On Tuesday" :date (t/date "2015-04-07")}] 2015
+    [{:name "Easter On Tuesday" :date (t/date "2016-03-29")}] 2016
+    [] 2017
+    [] 2018)
+
+  (are [expected year]
+       (= expected (gen/holidays-for-year year "test-resources/generate/expression-easter-observed-monday-tuesday-end-reverse-order.hol"))
+    [{:name "Easter On Tuesday" :date (t/date "2012-04-10")}] 2012
+    [{:name "Easter On Tuesday" :date (t/date "2013-04-02")}] 2013
+    [{:name "Easter On Tuesday" :date (t/date "2014-04-22")}] 2014
+    [{:name "Easter On Tuesday" :date (t/date "2015-04-07")}] 2015
+    [{:name "Easter On Tuesday" :date (t/date "2016-03-29")}] 2016
     [] 2017
     [] 2018))


### PR DESCRIPTION
Can now specify an observance rule such that Saturday holidays are observed on Monday, and Sunday is observed on Tuesday. This is useful to encode a few UK/Ireland holidays.